### PR TITLE
fix(fw): adjust rule for homeassistant comapnion app

### DIFF
--- a/data/firewall-filters/kids-allow-talos-flux-ingress.yaml
+++ b/data/firewall-filters/kids-allow-talos-flux-ingress.yaml
@@ -10,6 +10,7 @@ spec:
   direction: in
   interfaces:
     - opt3
+    - lan # without this, homeassisant companion app does not work
   protocol: any
   source:
     net: 192.168.20.0/24


### PR DESCRIPTION
I have no real idea, after investigating the issue with perplexity.ai checking mDNS broadcast over vnet (enabled via mDNS repeater), perplexity.ai pointed me to check for other network interfaces. I enabled access to the 192.168.1.0/24 net and it started working. I observed aditional packages on the firewall log from lan source 192.168.20.0/24 to 192.168.1.80/32, these packages have not been listed as blocked before, so basicaly i still have no idea but this is what happening. Companion app is now working as expected